### PR TITLE
Add offline UI fallback when backend is unreachable

### DIFF
--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get('/health')
+def health_check():
+    return {'status': 'ok'}
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.v1 import auth, external, parts, products, stores, tags
+from app.api.v1 import auth, external, health, parts, products, stores, tags
 
 # Load local .env if present (useful for local development)
 if os.getenv("RAILWAY_ENVIRONMENT") is None:
@@ -29,6 +29,7 @@ app.include_router(auth.router, prefix="/v1/auth", tags=["Auth"])
 app.include_router(products.router, prefix="/v1/products", tags=["Products"])
 app.include_router(external.router, prefix="/v1/external", tags=["External"])
 app.include_router(tags.router, prefix="/v1/tags", tags=["Tags"])
+app.include_router(health.router, prefix="/v1")
 
 
 @app.get("/")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    resp = client.get('/v1/health')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}
+

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,10 +1,18 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import App from './App';
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import App from './App'
 
 describe('App', () => {
-  it('renders the Home page by default', () => {
-    render(<App />);
-    expect(screen.getByText(/Latest products/i)).toBeInTheDocument();
-  });
-});
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true }) as any
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the Home page by default', async () => {
+    render(<App />)
+    expect(await screen.findByText(/Latest products/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,8 +7,26 @@ import Products from "./pages/Products";
 import AddProduct from "./pages/AddProduct";
 import AddStore from "./pages/AddStore";
 import ProductDetail from "./pages/ProductDetail";
+import { useBackendStatus } from './hooks/useBackendStatus'
 
 export default function App() {
+  const status = useBackendStatus()
+
+  if (status === 'checking') {
+    return <div className='p-8 text-center'>Checking backend status...</div>
+  }
+
+  if (status === 'offline') {
+    return (
+      <div className='flex h-screen items-center justify-center bg-gray-100'>
+        <div className='text-center'>
+          <h1 className='text-2xl font-bold'>⚠️ Backend offline</h1>
+          <p className='mt-2 text-gray-600'>We're doing maintenance or sleeping. Please try again later.</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <BrowserRouter>
       <Routes>
@@ -30,3 +48,4 @@ export default function App() {
     </BrowserRouter>
   );
 }
+

--- a/frontend/src/hooks/useBackendStatus.ts
+++ b/frontend/src/hooks/useBackendStatus.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export function useBackendStatus(): 'online' | 'offline' | 'checking' {
+    const [status, setStatus] = useState<'online' | 'offline' | 'checking'>('checking')
+
+    useEffect(() => {
+        const controller = new AbortController()
+        fetch(`${import.meta.env.VITE_API_BASE}/health`, { signal: controller.signal })
+            .then(res => {
+                if (!res.ok) throw new Error('Not OK')
+                setStatus('online')
+            })
+            .catch(() => setStatus('offline'))
+
+        return () => controller.abort()
+    }, [])
+
+    return status
+}


### PR DESCRIPTION
## Summary
- expose a `/health` endpoint in FastAPI
- show a full-screen offline notice in the React app
- check backend availability via new `useBackendStatus` hook
- update tests for the new behavior

## Testing
- `poetry run pytest`
- `VITE_API_BASE=http://localhost npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68855130a6748327bb43c8f243731494